### PR TITLE
allow option for enforcing unique key/value mappings

### DIFF
--- a/spec/filters/kv_spec.rb
+++ b/spec/filters/kv_spec.rb
@@ -433,4 +433,34 @@ describe LogStash::Filters::KV do
 
   end
 
+  describe "Removing duplicate key/value pairs" do
+    config <<-CONFIG
+      filter {
+        kv {
+          field_split => "&"
+          source => "source"
+          allow_duplicate_values => false
+        }
+      }
+    CONFIG
+
+    sample("source" => "foo=bar&foo=yeah&foo=yeah") do
+      insist { subject["[foo]"] } == ["bar", "yeah"]
+    end
+  end
+
+  describe "Allow duplicate key/value pairs by default" do
+    config <<-CONFIG
+      filter {
+        kv {
+          field_split => "&"
+          source => "source"
+        }
+      }
+    CONFIG
+
+    sample("source" => "foo=bar&foo=yeah&foo=yeah") do
+      insist { subject["[foo]"] } == ["bar", "yeah", "yeah"]
+    end
+  end
 end


### PR DESCRIPTION
in response to: https://github.com/elasticsearch/logstash/issues/1714

Adds `allow_duplicate_values` boolean option. When true, the plugin will enforce that only unique key/value pairs are recorded