### PR TITLE
Make include_brackets treat angle brackets as value wrappers too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.7
+  - With include_brackets enabled, angle brackets (\< and \>) are treated the same as square brackets and parentheses, making it easy to parse strings like "a=\<b\> c=\<d\>".
+  - An empty value_split option value now gives a useful error message.
+
 # 2.0.6
   - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
 # 2.0.5

--- a/logstash-filter-kv.gemspec
+++ b/logstash-filter-kv.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-kv'
-  s.version         = '2.0.6'
+  s.version         = '2.0.7'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This filter helps automatically parse messages (or specific event fields) which are of the 'foo=bar' variety."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/kv_spec.rb
+++ b/spec/filters/kv_spec.rb
@@ -14,7 +14,7 @@ describe LogStash::Filters::KV do
       }
     CONFIG
 
-    sample "hello=world foo=bar baz=fizz doublequoted=\"hello world\" singlequoted='hello world' bracketsone=(hello world) bracketstwo=[hello world]" do
+    sample "hello=world foo=bar baz=fizz doublequoted=\"hello world\" singlequoted='hello world' bracketsone=(hello world) bracketstwo=[hello world] bracketsthree=<hello world>" do
       insist { subject["hello"] } == "world"
       insist { subject["foo"] } == "bar"
       insist { subject["baz"] } == "fizz"
@@ -22,6 +22,7 @@ describe LogStash::Filters::KV do
       insist { subject["singlequoted"] } == "hello world"
       insist { subject["bracketsone"] } == "hello world"
       insist { subject["bracketstwo"] } == "hello world"
+      insist { subject["bracketsthree"] } == "hello world"
     end
   end
 


### PR DESCRIPTION
It's not uncommon to have the kv filter parse strings like

    a=<b> c=<d>

so it's reasonable that the include_brackets option treats angle brackets just like square brackets and parentheses and thus removes them before from the value before storing it in the event. Fixes #17.