### PR TITLE
Capture empty value_split value and give proper error message.

### DIFF
--- a/lib/logstash/filters/kv.rb
+++ b/lib/logstash/filters/kv.rb
@@ -87,7 +87,7 @@ class LogStash::Filters::KV < LogStash::Filters::Base
   config :field_split, :validate => :string, :default => ' '
 
 
-  # A string of characters to use as delimiters for identifying key-value relations.
+  # A non-empty string of characters to use as delimiters for identifying key-value relations.
   #
   # These characters form a regex character class and thus you must escape special regex
   # characters like `[` or `]` using `\`.
@@ -212,6 +212,15 @@ class LogStash::Filters::KV < LogStash::Filters::Base
   config :recursive, :validate => :boolean, :default => false
 
   def register
+    if @value_split.empty?
+      raise LogStash::ConfigurationError, I18n.t(
+        "logstash.agent.configuration.invalid_plugin_register",
+        :plugin => "filter",
+        :type => "kv",
+        :error => "Configuration option 'value_split' must be a non-empty string"
+      )
+    end
+
     @trim_re = Regexp.new("[#{@trim}]") if @trim
     @trimkey_re = Regexp.new("[#{@trimkey}]") if @trimkey
 

--- a/spec/filters/kv_spec.rb
+++ b/spec/filters/kv_spec.rb
@@ -629,4 +629,18 @@ describe LogStash::Filters::KV do
       end
     end
   end
+
+  describe "an empty value_split option should be reported" do
+    config <<-CONFIG
+      filter {
+        kv {
+          value_split => ""
+        }
+      }
+    CONFIG
+
+    sample("message" => "random message") do
+      insist { subject }.raises(LogStash::ConfigurationError)
+    end
+  end
 end


### PR DESCRIPTION
If the `value_split` option is empty and left to its own devices it'll result in a far from obvious RegexpError exception ("premature end of char-class"). Let's capture this and give the user a good error message.