### PR TITLE
Add support for transforming keys and values to lowercase, uppercase o…

### DIFF
--- a/lib/logstash/filters/kv.rb
+++ b/lib/logstash/filters/kv.rb
@@ -29,6 +29,11 @@ require "logstash/namespace"
 class LogStash::Filters::KV < LogStash::Filters::Base
   config_name "kv"
 
+  # Constants used for transform check
+  TRANSFORM_LOWERCASE_KEY = "lowercase"
+  TRANSFORM_UPPERCASE_KEY = "uppercase"
+  TRANSFORM_CAPITALIZE_KEY = "capitalize"
+
   # A string of characters to trim from the value. This is useful if your
   # values are wrapped in brackets or are terminated with commas (like postfix
   # logs).
@@ -60,8 +65,6 @@ class LogStash::Filters::KV < LogStash::Filters::Base
   #     }
   config :trimkey, :validate => :string
 
-
-
   # Transform values to lower case, upper case or capitals.
   #
   # For example, to capitalize all values:
@@ -71,7 +74,7 @@ class LogStash::Filters::KV < LogStash::Filters::Base
   #         transform_value => "capitalize"
   #       }
   #     }
-  config :transform_value, :validate => ["lowercase", "uppercase", "capitalize"]
+  config :transform_value, :validate => [TRANSFORM_LOWERCASE_KEY, TRANSFORM_UPPERCASE_KEY, TRANSFORM_CAPITALIZE_KEY]
 
   # Transform keys to lower case, upper case or capitals.
   #
@@ -82,7 +85,7 @@ class LogStash::Filters::KV < LogStash::Filters::Base
   #         transform_key => "lowercase"
   #       }
   #     }
-  config :transform_key, :validate => ["lowercase", "uppercase", "capitalize"]
+  config :transform_key, :validate => [TRANSFORM_LOWERCASE_KEY, TRANSFORM_UPPERCASE_KEY, TRANSFORM_CAPITALIZE_KEY]
 
   # A string of characters to use as delimiters for parsing out key-value pairs.
   #
@@ -295,11 +298,11 @@ class LogStash::Filters::KV < LogStash::Filters::Base
 
   def transform(text, method)
     case method
-    when "lowercase"
+    when TRANSFORM_LOWERCASE_KEY
       return text.downcase
-    when "uppercase"
+    when TRANSFORM_UPPERCASE_KEY
       return text.upcase
-    when "capitalize"
+    when TRANSFORM_CAPITALIZE_KEY
       return text.capitalize
     end
   end

--- a/lib/logstash/filters/kv.rb
+++ b/lib/logstash/filters/kv.rb
@@ -62,27 +62,27 @@ class LogStash::Filters::KV < LogStash::Filters::Base
 
 
 
-  # Normalize values to lower case, upper case or capitals.
+  # Transform values to lower case, upper case or capitals.
   #
   # For example, to capitalize all values:
   # [source,ruby]
   #     filter {
   #       kv {
-  #         norm => "capitalize"
+  #         transform_value => "capitalize"
   #       }
   #     }
-  config :norm, :validate => ["lowercase", "uppercase", "capitalize"]
+  config :transform_value, :validate => ["lowercase", "uppercase", "capitalize"]
 
-  # Normalize keys to lower case, upper case or capitals.
+  # Transform keys to lower case, upper case or capitals.
   #
   # For example, to lowercase all keys:
   # [source,ruby]
   #     filter {
   #       kv {
-  #         normkey => "lowercase"
+  #         transform_key => "lowercase"
   #       }
   #     }
-  config :normkey, :validate => ["lowercase", "uppercase", "capitalize"]
+  config :transform_key, :validate => ["lowercase", "uppercase", "capitalize"]
 
   # A string of characters to use as delimiters for parsing out key-value pairs.
   #
@@ -293,7 +293,7 @@ class LogStash::Filters::KV < LogStash::Filters::Base
     s =~ @value_split_re
   end
 
-  def norm(text, method)
+  def transform(text, method)
     case method
     when "lowercase"
       return text.downcase
@@ -315,7 +315,7 @@ class LogStash::Filters::KV < LogStash::Filters::Base
     text.scan(@scan_re) do |key, v1, v2, v3, v4, v5, v6|
       value = v1 || v2 || v3 || v4 || v5 || v6
       key = @trimkey ? key.gsub(@trimkey_re, "") : key
-      key = @normkey ? norm(key, @normkey) : key
+      key = @transform_key ? transform(key, @transform_key) : key
 
       # Bail out as per the values of include_keys and exclude_keys
       next if not include_keys.empty? and not include_keys.include?(key)
@@ -325,7 +325,7 @@ class LogStash::Filters::KV < LogStash::Filters::Base
       key = event.sprintf(@prefix) + key
 
       value = @trim ? value.gsub(@trim_re, "") : value
-      value = @norm ? norm(value, @norm) : value
+      value = @transform_value ? transform(value, @transform_value) : value
 
       # Bail out if inserting duplicate value in key mapping when unique_values
       # option is set to true.

--- a/spec/filters/kv_spec.rb
+++ b/spec/filters/kv_spec.rb
@@ -26,63 +26,63 @@ describe LogStash::Filters::KV do
     end
   end
 
-  describe  "test normalize keys to uppercase and values to lowercase" do
+  describe  "test transforming keys to uppercase and values to lowercase" do
     config <<-CONFIG
       filter {
         kv {
-          normkey => "uppercase"
-          norm => "lowercase"
+          transform_key => "uppercase"
+          transform_value => "lowercase"
         }
       }
     CONFIG
 
     sample "hello = world Foo =Bar BAZ= FIZZ doublequoteD = \"hellO worlD\" Singlequoted= 'Hello World' brAckets =(hello World)" do
-      insist { subject["HELLO"] } == "world"
-      insist { subject["FOO"] } == "bar"
-      insist { subject["BAZ"] } == "fizz"
-      insist { subject["DOUBLEQUOTED"] } == "hello world"
-      insist { subject["SINGLEQUOTED"] } == "hello world"
-      insist { subject["BRACKETS"] } == "hello world"
+      insist { subject.get("HELLO") } == "world"
+      insist { subject.get("FOO") } == "bar"
+      insist { subject.get("BAZ") } == "fizz"
+      insist { subject.get("DOUBLEQUOTED") } == "hello world"
+      insist { subject.get("SINGLEQUOTED") } == "hello world"
+      insist { subject.get("BRACKETS") } == "hello world"
     end
   end
 
-  describe  "test normalize keys to lowercase and values to uppercase" do
+  describe  "test transforming keys to lowercase and values to uppercase" do
     config <<-CONFIG
       filter {
         kv {
-          normkey => "lowercase"
-          norm => "uppercase"
+          transform_key => "lowercase"
+          transform_value => "uppercase"
         }
       }
     CONFIG
 
     sample "Hello = World fOo =bar baz= FIZZ DOUBLEQUOTED = \"hellO worlD\" singlequoted= 'hEllo wOrld' brackets =(HELLO world)" do
-      insist { subject["hello"] } == "WORLD"
-      insist { subject["foo"] } == "BAR"
-      insist { subject["baz"] } == "FIZZ"
-      insist { subject["doublequoted"] } == "HELLO WORLD"
-      insist { subject["singlequoted"] } == "HELLO WORLD"
-      insist { subject["brackets"] } == "HELLO WORLD"
+      insist { subject.get("hello") } == "WORLD"
+      insist { subject.get("foo") } == "BAR"
+      insist { subject.get("baz") } == "FIZZ"
+      insist { subject.get("doublequoted") } == "HELLO WORLD"
+      insist { subject.get("singlequoted") } == "HELLO WORLD"
+      insist { subject.get("brackets") } == "HELLO WORLD"
     end
   end
 
-  describe  "test capitalize keys and values" do
+  describe  "test transforming keys and values to capitals" do
     config <<-CONFIG
       filter {
         kv {
-          normkey => "capitalize"
-          norm => "capitalize"
+          transform_key => "capitalize"
+          transform_value => "capitalize"
         }
       }
     CONFIG
 
     sample "Hello = World fOo =bar baz= FIZZ DOUBLEQUOTED = \"hellO worlD\" singlequoted= 'hEllo wOrld' brackets =(HELLO world)" do
-      insist { subject["Hello"] } == "World"
-      insist { subject["Foo"] } == "Bar"
-      insist { subject["Baz"] } == "Fizz"
-      insist { subject["Doublequoted"] } == "Hello world"
-      insist { subject["Singlequoted"] } == "Hello world"
-      insist { subject["Brackets"] } == "Hello world"
+      insist { subject.get("Hello") } == "World"
+      insist { subject.get("Foo") } == "Bar"
+      insist { subject.get("Baz") } == "Fizz"
+      insist { subject.get("Doublequoted") } == "Hello world"
+      insist { subject.get("Singlequoted") } == "Hello world"
+      insist { subject.get("Brackets") } == "Hello world"
     end
   end
 

--- a/spec/filters/kv_spec.rb
+++ b/spec/filters/kv_spec.rb
@@ -26,6 +26,66 @@ describe LogStash::Filters::KV do
     end
   end
 
+  describe  "test normalize keys to uppercase and values to lowercase" do
+    config <<-CONFIG
+      filter {
+        kv {
+          normkey => "uppercase"
+          norm => "lowercase"
+        }
+      }
+    CONFIG
+
+    sample "hello = world Foo =Bar BAZ= FIZZ doublequoteD = \"hellO worlD\" Singlequoted= 'Hello World' brAckets =(hello World)" do
+      insist { subject["HELLO"] } == "world"
+      insist { subject["FOO"] } == "bar"
+      insist { subject["BAZ"] } == "fizz"
+      insist { subject["DOUBLEQUOTED"] } == "hello world"
+      insist { subject["SINGLEQUOTED"] } == "hello world"
+      insist { subject["BRACKETS"] } == "hello world"
+    end
+  end
+
+  describe  "test normalize keys to lowercase and values to uppercase" do
+    config <<-CONFIG
+      filter {
+        kv {
+          normkey => "lowercase"
+          norm => "uppercase"
+        }
+      }
+    CONFIG
+
+    sample "Hello = World fOo =bar baz= FIZZ DOUBLEQUOTED = \"hellO worlD\" singlequoted= 'hEllo wOrld' brackets =(HELLO world)" do
+      insist { subject["hello"] } == "WORLD"
+      insist { subject["foo"] } == "BAR"
+      insist { subject["baz"] } == "FIZZ"
+      insist { subject["doublequoted"] } == "HELLO WORLD"
+      insist { subject["singlequoted"] } == "HELLO WORLD"
+      insist { subject["brackets"] } == "HELLO WORLD"
+    end
+  end
+
+  describe  "test capitalize keys and values" do
+    config <<-CONFIG
+      filter {
+        kv {
+          normkey => "capitalize"
+          norm => "capitalize"
+        }
+      }
+    CONFIG
+
+    sample "Hello = World fOo =bar baz= FIZZ DOUBLEQUOTED = \"hellO worlD\" singlequoted= 'hEllo wOrld' brackets =(HELLO world)" do
+      insist { subject["Hello"] } == "World"
+      insist { subject["Foo"] } == "Bar"
+      insist { subject["Baz"] } == "Fizz"
+      insist { subject["Doublequoted"] } == "Hello World"
+      insist { subject["Singlequoted"] } == "Hello World"
+      insist { subject["Brackets"] } == "Hello World"
+    end
+  end
+
   describe  "test spaces attached to the field_split" do
     config <<-CONFIG
       filter {

--- a/spec/filters/kv_spec.rb
+++ b/spec/filters/kv_spec.rb
@@ -80,9 +80,9 @@ describe LogStash::Filters::KV do
       insist { subject["Hello"] } == "World"
       insist { subject["Foo"] } == "Bar"
       insist { subject["Baz"] } == "Fizz"
-      insist { subject["Doublequoted"] } == "Hello World"
-      insist { subject["Singlequoted"] } == "Hello World"
-      insist { subject["Brackets"] } == "Hello World"
+      insist { subject["Doublequoted"] } == "Hello world"
+      insist { subject["Singlequoted"] } == "Hello world"
+      insist { subject["Brackets"] } == "Hello world"
     end
   end
 


### PR DESCRIPTION
…r capitals.

This pull request adds two new configuration keys `transform_key` and `transform_value` that can be set to `lowercase`, `uppercase`, `capitalize` to transform either the keys or values. This should solve issue https://github.com/logstash-plugins/logstash-filter-kv/issues/24 and https://github.com/logstash-plugins/logstash-filter-kv/issues/16.