### PR TITLE
Change the "trim" regexp to support multiple trimmed characters

### DIFF
--- a/lib/logstash/filters/kv.rb
+++ b/lib/logstash/filters/kv.rb
@@ -286,8 +286,8 @@ class LogStash::Filters::KV < LogStash::Filters::Base
       )
     end
 
-    @trim_value_re = Regexp.new("^[#{@trim_value}]|[#{@trim_value}]$") if @trim_value
-    @trim_key_re = Regexp.new("^[#{@trim_key}]|[#{@trim_key}]$") if @trim_key
+    @trim_value_re = Regexp.new("^[#{@trim_value}]+|[#{@trim_value}]+$") if @trim_value
+    @trim_key_re = Regexp.new("^[#{@trim_key}]+|[#{@trim_key}]+$") if @trim_key
 
     @remove_char_value_re = Regexp.new("[#{@remove_char_value}]") if @remove_char_value
     @remove_char_key_re = Regexp.new("[#{@remove_char_key}]") if @remove_char_key

--- a/spec/filters/kv_spec.rb
+++ b/spec/filters/kv_spec.rb
@@ -709,7 +709,7 @@ describe LogStash::Filters::KV do
       plugin
     end
 
-    let(:message) { "key1= value1 with spaces | key2 with spaces =value2" }
+    let(:message) { "key1=  value1 with spaces    |  key2 with spaces  =value2" }
     let(:data) { {"message" => message} }
     let(:event) { LogStash::Event.new(data) }
     let(:options) {


### PR DESCRIPTION
Thr trim action should remove any number of selected characters
from the beginning and at the end of the string. Current implementation
removes only a single character. Changing the regexp will fix it.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
