### PR TITLE
option to split on multi characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.1.0
+  - feature: add option to split fields and values using a regex pattern (#55)
+
 ## 4.0.3
   - Update gemspec summary
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -135,7 +135,7 @@ To exclude `from` and `to`, but retain the `foo` key, you could use this configu
   * Value type is <<string,string>>
   * Default value is `" "`
 
-A string of characters to use as delimiters for parsing out key-value pairs.
+A string of characters to use as single-character field delimiters for parsing out key-value pairs.
 
 These characters form a regex character class and thus you must escape special regex
 characters like `[` or `]` using `\`.
@@ -159,6 +159,29 @@ fields:
 * `e: foo@bar.com`
 * `oq: bobo`
 * `ss: 12345`
+
+[id="plugins-{type}s-{plugin}-field_split_pattern"]
+===== `field_split_pattern`
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+A regex expression to use as field delimiter for parsing out key-value pairs.
+Useful to define multi-character field delimiters.
+Setting the `field_split_pattern` options will take precedence over the `field_split` option.
+
+Note that you should avoid using captured groups in your regex and you should be
+cautious with lookaheads or lookbehinds and positional anchors.
+
+For example, to split fields on a repetition of one or more colons
+`k1=v1:k2=v2::k3=v3:::k4=v4`:
+[source,ruby]
+    filter { kv { field_split_pattern => ":+" } }
+
+To split fields on a regex character that need escaping like the plus sign
+`k1=v1++k2=v2++k3=v3++k4=v4`:
+[source,ruby]
+    filter { kv { field_split_pattern => "\\+\\+" } }
 
 [id="plugins-{type}s-{plugin}-include_brackets"]
 ===== `include_brackets` 
@@ -393,7 +416,7 @@ For example, to trim `<`, `>`, `[`, `]` and `,` characters from values:
   * Value type is <<string,string>>
   * Default value is `"="`
 
-A non-empty string of characters to use as delimiters for identifying key-value relations.
+A non-empty string of characters to use as single-character value delimiters for parsing out key-value pairs.
 
 These characters form a regex character class and thus you must escape special regex
 characters like `[` or `]` using `\`.
@@ -403,6 +426,21 @@ For example, to identify key-values such as
 [source,ruby]
     filter { kv { value_split => ":" } }
 
+
+[id="plugins-{type}s-{plugin}-value_split_pattern"]
+===== `value_split_pattern`
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+A regex expression to use as value delimiter for parsing out key-value pairs.
+Useful to define multi-character value delimiters.
+Setting the `value_split_pattern` options will take precedence over the `value_split option`.
+
+Note that you should avoid using captured groups in your regex and you should be
+cautious with lookaheads or lookbehinds and positional anchors.
+
+See `field_split_pattern` for examples.
 
 
 [id="plugins-{type}s-{plugin}-common-options"]

--- a/logstash-filter-kv.gemspec
+++ b/logstash-filter-kv.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-kv'
-  s.version         = '4.0.3'
+  s.version         = '4.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parses key-value pairs"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This PR introduces the option to specify fields and values delimiters using a regex expression. This will allow splitting on more complex delimiters such a multi-characters delimiters.

The goal is to preserve backward compatibility on the current `field_split` and `value_split` config options semantic. Two new options are added: `field_split_pattern` and `value_split_pattern` and take as parameter a regex expression and are unset by default.

if `field_split_pattern` is set it will take precedence over `field_split`, idem for `value_split_pattern` and `value_split`. 