### PR TITLE
handle empty values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.1.1
+  - bugfix: correctly handle empty values between value separator and field separator (#58)
+
 ## 4.1.0
   - feature: add option to split fields and values using a regex pattern (#55)
 

--- a/lib/logstash/filters/kv.rb
+++ b/lib/logstash/filters/kv.rb
@@ -356,7 +356,7 @@ class LogStash::Filters::KV < LogStash::Filters::Base
       end
 
       # an unquoted value is a _captured_ sequence of characters or escaped spaces before a `field_split` or EOF.
-      value_patterns << /((?:\\ |.)+?)(?=#{Regexp::union(field_split, eof)})/
+      value_patterns << /((?:\\ |.)*?)(?=#{Regexp::union(field_split, eof)})/
 
       Regexp.union(*value_patterns)
     end

--- a/logstash-filter-kv.gemspec
+++ b/logstash-filter-kv.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-kv'
-  s.version         = '4.1.0'
+  s.version         = '4.1.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parses key-value pairs"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/kv_spec.rb
+++ b/spec/filters/kv_spec.rb
@@ -897,4 +897,37 @@ describe "multi character splitting" do
     end
   end
 
+  describe "handles empty values" do
+    let(:message) { 'a=1|b=|c=3' }
+
+    shared_examples "parse empty values" do
+      it "splits correctly upon empty value" do
+        subject.filter(event)
+
+        expect(event.get("a")).to eq("1")
+        expect(event.get("b")).to be_nil
+        expect(event.get("c")).to eq("3")
+      end
+    end
+
+    context "using char class splitters" do
+      let(:options) {
+        {
+            "field_split" => "|",
+            "value_split" => "=",
+        }
+      }
+      it_behaves_like "parse empty values"
+    end
+
+    context "using pattern splitters" do
+      let(:options) {
+        {
+            "field_split_pattern" => '\|',
+            "value_split_pattern" => "=",
+        }
+      }
+      it_behaves_like "parse empty values"
+    end
+  end
 end


### PR DESCRIPTION
This fixes #57

Empty values, such as with `a=1|b=|c=3` where not correctly handled and would be parsed as
```
{
       "message" => "a=1|b=|c=3",
             "a" => "1",
             "b" => "|c=3",
}
```

This PR fixes this by allowing empty values between the value separator and the field separator. I added specific specs for this case and all other specs are passing. 