### PR TITLE
Docs : add missing keys to configuration options

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -56,6 +56,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-default_keys>> |<<hash,hash>>|No
 | <<plugins-{type}s-{plugin}-exclude_keys>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-field_split>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-field_split_pattern>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-include_brackets>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-include_keys>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-prefix>> |<<string,string>>|No
@@ -69,6 +70,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-trim_key>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-trim_value>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-value_split>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-value_split_pattern>> |<<string,string>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all


### PR DESCRIPTION
Add "field_split_pattern" and "value_split_pattern" keys to table listing all kv filter configuration options
