### PR TITLE
make quoted capture less greedy when we have unambiguous separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.2
+  - bugfix: improves trim_key and trim_value to trim any _sequence_ of matching characters from the beginning and ends of the corresponding keys and values; a previous implementation limitited trim to a single character from each end, which was surprising.
+  - bugfix: fixes issue where we can fail to correctly break up a sequence that includes a partially-quoted value followed by another fully-quoted value by slightly reducing greediness of quoted-value captures.
+
 ## 4.1.1
   - bugfix: correctly handle empty values between value separator and field separator (#58)
 

--- a/lib/logstash/filters/kv.rb
+++ b/lib/logstash/filters/kv.rb
@@ -422,8 +422,8 @@ class LogStash::Filters::KV < LogStash::Filters::Base
     open_pattern = /#{Regexp.quote(quote_sequence)}/
     close_pattern = /#{Regexp.quote(close_quote_sequence)}/
 
-    # matches a sequence of zero or more characters that is followed by the `close_quote_sequence`
-    quoted_value_pattern = /(?:.)*?(?=#{Regexp.quote(close_quote_sequence)})/
+    # matches a sequence of zero or more characters are _not_ the `close_quote_sequence`
+    quoted_value_pattern = /[^#{Regexp.quote(close_quote_sequence)}]*/
 
     /#{open_pattern}(#{quoted_value_pattern})#{close_pattern}/
   end

--- a/lib/logstash/filters/kv.rb
+++ b/lib/logstash/filters/kv.rb
@@ -331,8 +331,8 @@ class LogStash::Filters::KV < LogStash::Filters::Base
       )
     end
 
-    @trim_value_re = Regexp.new("^[#{@trim_value}]|[#{@trim_value}]$") if @trim_value
-    @trim_key_re = Regexp.new("^[#{@trim_key}]|[#{@trim_key}]$") if @trim_key
+    @trim_value_re = Regexp.new("^[#{@trim_value}]+|[#{@trim_value}]+$") if @trim_value
+    @trim_key_re = Regexp.new("^[#{@trim_key}]+|[#{@trim_key}]+$") if @trim_key
 
     @remove_char_value_re = Regexp.new("[#{@remove_char_value}]") if @remove_char_value
     @remove_char_key_re = Regexp.new("[#{@remove_char_key}]") if @remove_char_key

--- a/logstash-filter-kv.gemspec
+++ b/logstash-filter-kv.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-kv'
-  s.version         = '4.1.1'
+  s.version         = '4.1.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parses key-value pairs"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This PR contains a couple separate fixes, that rely on each other; each fix is
documented in its own separate commit, but the commits must be applied _in
order_.


***

## Greediness of Quoted Values

    In [logstash-plugins/logstash-filter-kv#60][], GitHub user @robcowart reports
    that in some scenarios we can fail to split on match of `field_split_pattern`.
    
    The example given is a partially-quoted value, with additional bytes between
    it and the unambiguous separator, followed by another key and quoted value.

    Since the quoted value isn't immediately followed by a field splitter, our
    semi-greedy quoted-value capture was too greedy, continuing to consume until
    it found a close-quote that would be followed by either a field-split or EOF.
    
    Here, we become much less greedy, capturing any sequence of characters that
    is _not_ the close-quote character.

    [logstash-plugins/logstash-filter-kv#60]: https://github.com/logstash-plugins/logstash-filter-kv/issues/60

## Greediness of `trim_key` and `trim_value` operations
    
    In logstash-plugins/logstash-filter-kv#59, GitHub user @lennardk reports that
    the `trim_key` and `trim_value` patterns are only trimming a single character
    from the beginning and end of the keys and values respectively.
    
    By making the patterns match one-or-more characters anchored to the head or
    tail of the string, we can better mimic the expected trim behaviour.
    
    Resolves: logstash-plugins/logstash-filter-kv#59