### PR TITLE
Add `whitespace => strict` mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.2.0
+ - feature: adds `whitespace => strict` mode, which allows the parser to behave more predictably when input is known to avoid unnecessary whitespace.
+
 ## 4.1.2
   - bugfix: improves trim_key and trim_value to trim any _sequence_ of matching characters from the beginning and ends of the corresponding keys and values; a previous implementation limitited trim to a single character from each end, which was surprising.
   - bugfix: fixes issue where we can fail to correctly break up a sequence that includes a partially-quoted value followed by another fully-quoted value by slightly reducing greediness of quoted-value captures.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -71,6 +71,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-trim_value>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-value_split>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-value_split_pattern>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-whitespace>> |<<string,string>>, one of `["strict", "lenient"]`|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -444,6 +445,23 @@ cautious with lookaheads or lookbehinds and positional anchors.
 
 See `field_split_pattern` for examples.
 
+[id="plugins-{type}s-{plugin}-whitespace"]
+===== `whitespace`
+
+  * Value can be any of: `lenient`, `strict`
+  * Default value is `lenient`
+
+An option specifying whether to be _lenient_ or _strict_ with the acceptance of unnecessary
+whitespace surrounding the configured value-split sequence.
+
+By default the plugin is run in `lenient` mode, which ignores spaces that occur before or
+after the value-splitter. While this allows the plugin to make reasonable guesses with most
+input, in some situations it may be too lenient.
+
+You may want to enable `whitespace => strict` mode if you have control of the input data and
+can guarantee that no extra spaces are added surrounding the pattern you have defined for
+splitting values. Doing so will ensure that a _field-splitter_ sequence immediately following
+a _value-splitter_ will be interpreted as an empty field.
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]


### PR DESCRIPTION
When configured with a space for its `field_split` (as is default), the
leniency in acceptance of optional spaces surrounding the `value_split`
prevents the parser from being able to detect an unquoted "empty" field.

By adding an opt-in whitespace mode that is strict and does not allow
unnecessary whitespace, we enable users who behave in this strict manner
to specify "null" or "empty" fields in their events.

***

This PR also includes a net-no-op refactor in a separate commit that
simplifies the generated regexp, reducing the reliance of complex
lookahead assertions and teasing apart the support for optional
whitespace sequences vs use of space as a `field_split`.

***

Resolves #65 
Resolves #37