### PR TITLE
handle runtime errors instead of allowing plugin to crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 4.2.0
- - feature: adds `whitespace => strict` mode, which allows the parser to behave more predictably when input is known to avoid unnecessary whitespace.
+ - Added `whitespace => strict` mode, which allows the parser to behave more predictably when input is known to avoid unnecessary whitespace.
+ - Added error handling, which tags the event with `_kv_filter_error` if an exception is raised while handling an event instead of allowing the plugin to crash.
 
 ## 4.1.2
   - bugfix: improves trim_key and trim_value to trim any _sequence_ of matching characters from the beginning and ends of the corresponding keys and values; a previous implementation limitited trim to a single character from each end, which was surprising.

--- a/lib/logstash/filters/kv.rb
+++ b/lib/logstash/filters/kv.rb
@@ -418,6 +418,11 @@ class LogStash::Filters::KV < LogStash::Filters::Base
     end
 
     filter_matched(event)
+  rescue => ex
+    meta = { :exception => ex.message }
+    meta[:backtrace] = ex.backtrace if logger.debug?
+    logger.warn('Exception while parsing KV', meta)
+    event.tag('_kv_filter_error')
   end
 
   private

--- a/logstash-filter-kv.gemspec
+++ b/logstash-filter-kv.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-kv'
-  s.version         = '4.1.2'
+  s.version         = '4.2.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parses key-value pairs"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
While this plugin is designed to be flexible with inputs, there are situations
where it calls out to external APIs (such as the Logstash Event API) that can
raise runtime exceptions.

When an exception is raised, tag the event with `_kv_filter_error` and warn
instead of allowing the exception to blow through the stack and crash the
plugin. If the logger has debug enabled, include the exception's backtrace.

Also fixes changelog entry and bumps version for release.