### PR TITLE
merge into existing target, new tests and DRYing

### DIFF
--- a/lib/logstash/filters/kv.rb
+++ b/lib/logstash/filters/kv.rb
@@ -411,8 +411,10 @@ class LogStash::Filters::KV < LogStash::Filters::Base
     return if kv.empty?
 
     if @target
-      @logger.debug? && @logger.debug("Overwriting existing target field", :target => @target)
-      event.set(@target, kv)
+      @logger.debug? && @logger.debug("Merging into existing target field", :target => @target)
+      t = event.get(@target)
+      t = {} unless t.is_a?(Hash)
+      event.set(@target, t.merge(kv))
     else
       kv.each{|k, v| event.set(k, v)}
     end


### PR DESCRIPTION
This fixes issue #43 which is a regression introduced into the kv filter v2.0.3 and above.
Previously if an existing `target` field existed in the event, the kv fields were merged but the refactor at 2.0.3 changed that and now the `target` field is always overwritten.

This PR brings back the pre 2.0.3 behaviour and also add a specific test for that. The specs have also been cleaned up a little bit to DRY the plugin instance creation.