### PR TITLE
fix performance regression when using `field_split` and `value_split` char classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.2.1
+ - Fixes performance regression introduced in 4.1.0 ([#70](https://github.com/logstash-plugins/logstash-filter-kv/issues/70))
+
 ## 4.2.0
  - Added `whitespace => strict` mode, which allows the parser to behave more predictably when input is known to avoid unnecessary whitespace.
  - Added error handling, which tags the event with `_kv_filter_error` if an exception is raised while handling an event instead of allowing the plugin to crash.

--- a/logstash-filter-kv.gemspec
+++ b/logstash-filter-kv.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-kv'
-  s.version         = '4.2.0'
+  s.version         = '4.2.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parses key-value pairs"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Resolves: #70

When I implemented split-by-pattern, my implementation introduced a significant performance regression.

Essentially, a negated character class is significantly faster than the way in which I constructed a negated pattern-match (lookahead + single character).

This PR ensures we use negated character classes wherever practical, and continues to use the less-performant method mentioned above only when doing work that cannot be done with negated character classes.

Using the input and config from #70 and the expressions generated by the plugin, I'm able to show that this PR brings performance of the generated expressions back to pre-regression status:

> ~~~
> ╭─{ yaauie@castrovel:~/src/elastic/logstash-plugins/logstash-filter-kv (✔ performance-regression-fix) }
> ╰─● ruby benchmark.ips.ruby
> Warming up --------------------------------------
>                4.0.3     2.041k i/100ms
>                4.2.0     1.269k i/100ms
>    negated-charclass     2.118k i/100ms
> Calculating -------------------------------------
>                4.0.3     21.505k (± 3.7%) i/s -      1.290M in  60.070405s
>                4.2.0     12.933k (± 4.6%) i/s -    774.090k in  60.014354s
>    negated-charclass     21.703k (± 4.0%) i/s -      1.300M in  60.031555s
> 
> Comparison:
>    negated-charclass:    21703.0 i/s
>                4.0.3:    21505.1 i/s - same-ish: difference falls within error
>                4.2.0:    12932.8 i/s - 1.68x  slower
> 
> ruby benchmark.ips.ruby  221.12s user 1.34s system 104% cpu 3:32.68 total
> [success (212.000s)]                                                        
> ~~~