### PR TITLE
Add a Timeout Enforcer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.3.0 - UNRELEASED
+ - Added a timeout enforcer which prevents inputs that are pathological against the generated parser from blocking
+   the pipeline. By default, timeout is a generous 30s, but can be configured or disabled entirely with the new
+   `timeout_millis` and `tag_on_timeout` directives ([#79](https://github.com/logstash-plugins/logstash-filter-kv/pull/79))
+
 ## 4.2.1
  - Fixes performance regression introduced in 4.1.0 ([#70](https://github.com/logstash-plugins/logstash-filter-kv/issues/70))
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -65,6 +65,8 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-remove_char_value>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-source>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-tag_on_timeout>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-timeout_millis>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-transform_key>> |<<string,string>>, one of `["lowercase", "uppercase", "capitalize"]`|No
 | <<plugins-{type}s-{plugin}-transform_value>> |<<string,string>>, one of `["lowercase", "uppercase", "capitalize"]`|No
 | <<plugins-{type}s-{plugin}-trim_key>> |<<string,string>>|No
@@ -334,6 +336,28 @@ event, as individual fields.
 For example, to place all keys into the event field kv:
 [source,ruby]
     filter { kv { target => "kv" } }
+
+[id="plugins-{type}s-{plugin}-tag_on_timeout"]
+===== `tag_on_timeout`
+
+  * Value type is <<string,string>>
+  * The default value for this setting is `_kv_filter_timeout`.
+
+When timeouts are enabled and a kv operation is aborted, the event is tagged
+with the provided value (see: <<plugins-{type}s-{plugin}-timeout_millis>>).
+
+[id="plugins-{type}s-{plugin}-timeout_millis"]
+===== `timeout_millis`
+
+  * Value type is <<number, number>>
+  * The default value for this setting is 30000 (30 seconds).
+  * Set to zero (`0`) to disable timeouts
+
+Timeouts provide a safeguard against inputs that are pathological against the
+regular expressions that are used to extract key/value pairs. When parsing an
+event exceeds this threshold the operation is aborted and the event is tagged
+in order to prevent the operation from blocking the pipeline
+(see: <<plugins-{type}s-{plugin}-tag_on_timeout>>).
 
 [id="plugins-{type}s-{plugin}-transform_key"]
 ===== `transform_key` 

--- a/lib/logstash/filters/kv.rb
+++ b/lib/logstash/filters/kv.rb
@@ -317,6 +317,16 @@ class LogStash::Filters::KV < LogStash::Filters::Base
   #
   config :whitespace, :validate => %w(strict lenient), :default => "lenient"
 
+  # Attempt to terminate regexps after this amount of time.
+  # This applies per source field value if event has multiple values in the source field.
+  # This will never timeout early, but may take a little longer to timeout.
+  # Actual timeout is approximate based on a 250ms quantization.
+  # Set to 0 to disable timeouts
+  config :timeout_millis, :validate => :number, :default => 30_000
+
+  # Tag to apply if a kv regexp times out.
+  config :tag_on_timeout, :validate => :string, :default => '_kv_filter_timeout'
+
   def register
     if @value_split.empty?
       raise LogStash::ConfigurationError, I18n.t(
@@ -392,21 +402,26 @@ class LogStash::Filters::KV < LogStash::Filters::Base
     @value_split_re = value_split_pattern
 
     @logger.debug? && @logger.debug("KV scan regex", :regex => @scan_re.inspect)
+
+    @timeout_enforcer = initialize_timeout_enforcer
+    @timeout_enforcer.start!
   end
 
   def filter(event)
     kv = Hash.new
     value = event.get(@source)
 
-    case value
-    when nil
-      # Nothing to do
-    when String
-      parse(value, event, kv)
-    when Array
-      value.each { |v| parse(v, event, kv) }
-    else
-      @logger.warn("kv filter has no support for this type of data", :type => value.class, :value => value)
+    @timeout_enforcer.execute do
+      case value
+      when nil
+        # Nothing to do
+      when String
+        parse(value, event, kv)
+      when Array
+        value.each { |v| parse(v, event, kv) }
+      else
+        @logger.warn("kv filter has no support for this type of data", :type => value.class, :value => value)
+      end
     end
 
     # Add default key-values for missing keys
@@ -422,6 +437,10 @@ class LogStash::Filters::KV < LogStash::Filters::Base
     end
 
     filter_matched(event)
+
+  rescue TimeoutException => e
+    logger.warn("Timeout reached in KV filter with value #{summarize(value)}")
+    event.tag(@tag_on_timeout)
   rescue => ex
     meta = { :exception => ex.message }
     meta[:backtrace] = ex.backtrace if logger.debug?
@@ -429,7 +448,35 @@ class LogStash::Filters::KV < LogStash::Filters::Base
     event.tag('_kv_filter_error')
   end
 
+  def close
+    @timeout_enforcer.stop!
+  end
+
   private
+
+  # @overload summarize(value)
+  #   @param value [Array]
+  #   @return [String]
+  # @overload summarize(value)
+  #   @param value [String]
+  #   @return [String]
+  def summarize(value)
+    if value.kind_of?(Array)
+      value.map(&:to_s).map do |entry|
+        summarize(entry)
+      end.to_s
+    end
+
+    value = value.to_s
+
+    value.bytesize < 255 ? "`#{value}`" : "entry too large; first 255 chars are `#{value[0..255].dump}`"
+  end
+
+  def initialize_timeout_enforcer
+    return NULL_TIMEOUT_ENFORCER if @timeout_millis <= 0
+
+    TimeoutEnforcer.new(logger, @timeout_millis * 1_000_000)
+  end
 
   def has_value_splitter?(s)
     s =~ @value_split_re
@@ -542,6 +589,95 @@ class LogStash::Filters::KV < LogStash::Filters::Base
         kv_keys[key] = value
       end
     end
-
   end
+
+  class TimeoutException < RuntimeError
+  end
+
+  class TimeoutEnforcer
+    def initialize(logger, timeout_nanos)
+      @logger = logger
+      @running = java.util.concurrent.atomic.AtomicBoolean.new(false)
+      @timeout_nanos = timeout_nanos
+
+      # Stores running matches with their start time, this is used to cancel long running matches
+      # Is a map of Thread => start_time
+      @threads_to_start_time = java.util.concurrent.ConcurrentHashMap.new
+    end
+
+    def execute(&block)
+      begin
+        thread = java.lang.Thread.currentThread()
+        @threads_to_start_time.put(thread, java.lang.System.nanoTime)
+
+        yield
+
+      rescue InterruptedRegexpError, java.lang.InterruptedException => e
+        raise TimeoutException.new
+      ensure
+        # If the block finished, but interrupt was called after, we'll want to
+        # clear the interrupted status anyway
+        @threads_to_start_time.remove(thread)
+        thread.interrupted
+      end
+    end
+
+    def start!
+      @running.set(true)
+      @logger.debug("Starting timeout enforcer (#{@timeout_nanos}ns)")
+      @timer_thread = Thread.new do
+        while @running.get()
+          begin
+            cancel_timed_out!
+          rescue Exception => e
+            @logger.error("Error while attempting to check/cancel excessively long kv patterns",
+                          :message => e.message,
+                          :class => e.class.name,
+                          :backtrace => e.backtrace
+            )
+          end
+          sleep 0.25
+        end
+      end
+    end
+
+    def stop!
+      @running.set(false)
+      @logger.debug("Shutting down timeout enforcer")
+      # Check for the thread mostly for a fast start/shutdown scenario
+      @timer_thread.join if @timer_thread
+    end
+
+    private
+
+    def cancel_timed_out!
+      now = java.lang.System.nanoTime # save ourselves some nanotime calls
+      @threads_to_start_time.keySet.each do |thread|
+        # Use compute to lock this value
+        @threads_to_start_time.computeIfPresent(thread) do |thread, start_time|
+          if start_time < now && now - start_time > @timeout_nanos
+            thread.interrupt
+            nil # Delete the key
+          else
+            start_time # preserve the key
+          end
+        end
+      end
+    end
+  end
+
+  class NullTimeoutEnforcer
+    def execute(&block)
+      yield
+    end
+
+    def start!
+      # no-op
+    end
+
+    def stop!
+      # no-op
+    end
+  end
+  NULL_TIMEOUT_ENFORCER = NullTimeoutEnforcer.new
 end


### PR DESCRIPTION
Adds support for `timeout_millis` and `tag_on_timeout`, which allows us to prevent pathological inputs from blocking the pipeline indefinitely. The timeout-enforcer is borrowed heavily from the one included with the grok filter.

By default, this enables the timeout enforcer with a 30-second timeout that is more than generous enough to handle even mildly-pathological pattern matches.

