### PR TITLE
make failure tag configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
  - Added a timeout enforcer which prevents inputs that are pathological against the generated parser from blocking
    the pipeline. By default, timeout is a generous 30s, but can be configured or disabled entirely with the new
    `timeout_millis` and `tag_on_timeout` directives ([#79](https://github.com/logstash-plugins/logstash-filter-kv/pull/79))
+ - Made error-handling configurable with `tag_on_failure` directive.
 
 ## 4.2.1
  - Fixes performance regression introduced in 4.1.0 ([#70](https://github.com/logstash-plugins/logstash-filter-kv/issues/70))

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -65,6 +65,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-remove_char_value>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-source>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-tag_on_failure>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-tag_on_timeout>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-timeout_millis>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-transform_key>> |<<string,string>>, one of `["lowercase", "uppercase", "capitalize"]`|No
@@ -336,6 +337,16 @@ event, as individual fields.
 For example, to place all keys into the event field kv:
 [source,ruby]
     filter { kv { target => "kv" } }
+
+[id="plugins-{type}s-{plugin}-tag_on_failure"]
+===== `tag_on_failure`
+
+  * Value type is <<string,string>>
+  * The default value for this setting is `_kv_filter_error`.
+
+When a kv operation causes a runtime exception to be thrown within the plugin,
+the operation is safely aborted without crashing the plugin, and the event is
+tagged with the provided value.
 
 [id="plugins-{type}s-{plugin}-tag_on_timeout"]
 ===== `tag_on_timeout`

--- a/lib/logstash/filters/kv.rb
+++ b/lib/logstash/filters/kv.rb
@@ -327,6 +327,9 @@ class LogStash::Filters::KV < LogStash::Filters::Base
   # Tag to apply if a kv regexp times out.
   config :tag_on_timeout, :validate => :string, :default => '_kv_filter_timeout'
 
+  # Tag to apply if kv errors
+  config :tag_on_failure, :validate => :string, :default => '_kv_filter_error'
+
   def register
     if @value_split.empty?
       raise LogStash::ConfigurationError, I18n.t(
@@ -445,7 +448,7 @@ class LogStash::Filters::KV < LogStash::Filters::Base
     meta = { :exception => ex.message }
     meta[:backtrace] = ex.backtrace if logger.debug?
     logger.warn('Exception while parsing KV', meta)
-    event.tag('_kv_filter_error')
+    event.tag(@tag_on_failure)
   end
 
   def close

--- a/spec/filters/kv_spec.rb
+++ b/spec/filters/kv_spec.rb
@@ -1093,6 +1093,14 @@ context 'runtime errors' do
 
       plugin.filter(event)
     end
+    context 'when a custom tag is defined' do
+      let(:options) { super().merge("tag_on_failure" => "KV-ERROR")}
+      it 'tags the event with the custom tag' do
+        plugin.filter(event)
+        expect(event.get('tags')).to_not be_nil
+        expect(event.get('tags')).to include('KV-ERROR')
+      end
+    end
   end
 end
 


### PR DESCRIPTION
Since we recently added `tag_on_timeout` and `timeout_millis` that are analogous to the same directives in the Grok filter, this change brings the `tag_on_failure` flag over, too.