### PR TITLE
Fix asciidoc formatting in doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.3.1
+ - Fixed asciidoc formatting in documentation
+
 ## 4.3.0
  - Added a timeout enforcer which prevents inputs that are pathological against the generated parser from blocking
    the pipeline. By default, timeout is a generous 30s, but can be configured or disabled entirely with the new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 4.3.1
- - Fixed asciidoc formatting in documentation
+ - Fixed asciidoc formatting in documentation [#81](https://github.com/logstash-plugins/logstash-filter-kv/pull/81)
 
 ## 4.3.0
  - Added a timeout enforcer which prevents inputs that are pathological against the generated parser from blocking

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -146,7 +146,7 @@ A string of characters to use as single-character field delimiters for parsing o
 These characters form a regex character class and thus you must escape special regex
 characters like `[` or `]` using `\`.
 
-#### Example with URL Query Strings
+*Example with URL Query Strings*
 
 For example, to split out the args from a url query string such as
 `?pin=12345~0&d=123&e=foo@bar.com&oq=bobo&ss=12345`:

--- a/logstash-filter-kv.gemspec
+++ b/logstash-filter-kv.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-kv'
-  s.version         = '4.3.0'
+  s.version         = '4.3.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parses key-value pairs"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
We don't have enough heading levels to make this an official heading. Instead, I made it bold to set it apart from the other text. 
