### PR TITLE
Resolve potential race conditions in pipeline shutdown.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
  - Resolved potential race condition in pipeline shutdown where the timeout enforcer could be shut down while work was still in-flight, potentially leading to stuck pipelines.
+ - Resolved potential race condition in pipeline shutdown where work could be submitted to the timeout enforcer after it had been shutdown, potentially leading to stuck pipelines.
 
 ## 4.3.1
  - Fixed asciidoc formatting in documentation [#81](https://github.com/logstash-plugins/logstash-filter-kv/pull/81)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+ - Resolved potential race condition in pipeline shutdown where the timeout enforcer could be shut down while work was still in-flight, potentially leading to stuck pipelines.
+
 ## 4.3.1
  - Fixed asciidoc formatting in documentation [#81](https://github.com/logstash-plugins/logstash-filter-kv/pull/81)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 4.3.2
  - Resolved potential race condition in pipeline shutdown where the timeout enforcer could be shut down while work was still in-flight, potentially leading to stuck pipelines.
  - Resolved potential race condition in pipeline shutdown where work could be submitted to the timeout enforcer after it had been shutdown, potentially leading to stuck pipelines.
 

--- a/lib/logstash/filters/kv.rb
+++ b/lib/logstash/filters/kv.rb
@@ -609,6 +609,11 @@ class LogStash::Filters::KV < LogStash::Filters::Base
     end
 
     def execute(&block)
+      # If the enforcer is not running, either we failed to start it or it has
+      # already been stopped; in either case, we cannot reliably enforce the timeout
+      # so we raise a RuntimeError instead.
+      fail("TimeoutEnforcer not running.") unless alive?
+
       begin
         thread = java.lang.Thread.currentThread()
         @threads_to_start_time.put(thread, java.lang.System.nanoTime)
@@ -649,6 +654,10 @@ class LogStash::Filters::KV < LogStash::Filters::Base
       @logger.debug("Shutting down timeout enforcer")
       # Check for the thread mostly for a fast start/shutdown scenario
       @timer_thread.join if @timer_thread
+    end
+
+    def alive?
+      @running.get() && @timer_thread && @timer_thread.alive?
     end
 
     private

--- a/lib/logstash/filters/kv.rb
+++ b/lib/logstash/filters/kv.rb
@@ -629,7 +629,7 @@ class LogStash::Filters::KV < LogStash::Filters::Base
       @running.set(true)
       @logger.debug("Starting timeout enforcer (#{@timeout_nanos}ns)")
       @timer_thread = Thread.new do
-        while @running.get()
+        while @running.get() || !@threads_to_start_time.is_empty
           begin
             cancel_timed_out!
           rescue Exception => e

--- a/logstash-filter-kv.gemspec
+++ b/logstash-filter-kv.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-kv'
-  s.version         = '4.3.1'
+  s.version         = '4.3.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parses key-value pairs"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Resolves two separate potential race conditions that could occur during pipeline shutdown, resulting in a stalled shutdown sequence.

1. keep timeout enforcer alive as long as it has work to do
2. prevent timeout enforcer from accepting new work when it is not running