### PR TITLE
Make log value truncation message more clear

### DIFF
--- a/lib/logstash/filters/kv.rb
+++ b/lib/logstash/filters/kv.rb
@@ -478,7 +478,7 @@ class LogStash::Filters::KV < LogStash::Filters::Base
 
     value = value.to_s
 
-    value.bytesize < 255 ? "`#{value}`" : "entry too large; first 255 chars are `#{value[0..255].dump}`"
+    value.bytesize < 255 ? "`#{value.dump}`" : "(entry too large to show; showing first 255 characters) `#{value[0..255].dump}`[...]"
   end
   
   def has_value_splitter?(s)


### PR DESCRIPTION
Currently, the value emitted from `KV#summarize`  is emitted in a log
message of format:
   `"Timeout reached in KV filter with value entry #{summary}"`

When summary starts with `too large`, this ends up implying that
the value itself is too large for the KV filter to process.

By parenthesizing the truncation note, we can make the resulting
message clearer.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
