### PR TITLE
log: clarify action steps when timeouts cannot be enforced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.4.2
+ - Improved action call-out of log warning when this plugin cannot enforce timeouts [#93](https://github.com/logstash-plugins/logstash-filter-kv/pull/93)
+
 ## 4.4.1
  - Fixed issue where a `field_split_pattern` containing a literal backslash failed to match correctly [#87](https://github.com/logstash-plugins/logstash-filter-kv/issues/87)
 

--- a/lib/logstash/filters/kv.rb
+++ b/lib/logstash/filters/kv.rb
@@ -332,8 +332,10 @@ class LogStash::Filters::KV < LogStash::Filters::Base
   def register
     # Too late to set the regexp interruptible flag, at least warn if it is not set.
     require 'java'
-    if java.lang.System.getProperty("jruby.regexp.interruptible") != "true"
-      logger.warn("KV Filter registered without jruby interruptible regular expressions enabled (`-Djruby.regexp.interruptible=true`); timeouts may not be respected.")
+    if java.lang.System.getProperty("jruby.regexp.interruptible") != "true" && @timeout_millis > 0
+      logger.warn("KV Filter registered with `timeout_millis` safeguard enabled, but a required flag is missing so timeouts cannot be reliably enforced. " +
+                  "Without this safeguard, runaway matchers in the KV filter may lead to high CPU usage and stalled pipelines. " +
+                  "To resolve, add `-Djruby.regexp.interruptible=true` to your `config/jvm.options` and restart the Logstash process.")
     end
 
     if @value_split.empty?

--- a/logstash-filter-kv.gemspec
+++ b/logstash-filter-kv.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-kv'
-  s.version         = '4.4.1'
+  s.version         = '4.4.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parses key-value pairs"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Prior message was technically accurate, but didn't lead users to action and created confusion:

> KV Filter registered without jruby interruptible regular expressions enabled (`-Djruby.regexp.interruptible=true`); timeouts may not be respected.

Log message is now clearer about both intent and required actions to remediate:

> KV Filter registered with `timeout_millis` safeguard enabled, but a required flag is missing so timeouts cannot be reliably enforced. Without this safeguard, runaway matchers in the KV filter may lead to high CPU usage and stalled pipelines. To resolve, add `-Djruby.regexp.interruptible=true` to your `config/jvm.options` and restart the Logstash process."

Additionally, we skip logging this message entirely if the plugin is explicitly configured with `timeout_millis => 0` to disable timeouts.