### PR TITLE
Feat:  check that target is set in ECS mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.5.0
+ - Feat: check that target is set in ECS mode [#96](https://github.com/logstash-plugins/logstash-filter-kv/pull/96)
+
 ## 4.4.1
  - Fixed issue where a `field_split_pattern` containing a literal backslash failed to match correctly [#87](https://github.com/logstash-plugins/logstash-filter-kv/issues/87)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -44,6 +44,13 @@ in case your data is not structured using `=` signs and whitespace.
 For example, this filter can also be used to parse query parameters like
 `foo=bar&baz=fizz` by setting the `field_split` parameter to `&`.
 
+[id="plugins-{type}s-{plugin}-ecs_metadata"]
+==== Event Metadata and the Elastic Common Schema (ECS)
+
+The plugin behaves the same regardless of ECS compatibility, except giving a warning when ECS is enabled and `target` isn't set.
+
+TIP: Set the `target` option to avoid potential schema conflicts.
+
 [id="plugins-{type}s-{plugin}-options"]
 ==== Kv Filter Configuration Options
 
@@ -54,6 +61,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-allow_duplicate_values>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-default_keys>> |<<hash,hash>>|No
+| <<plugins-{type}s-{plugin}-ecs_compatibility>> | <<string,string>>|No
 | <<plugins-{type}s-{plugin}-exclude_keys>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-field_split>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-field_split_pattern>> |<<string,string>>|No
@@ -116,6 +124,17 @@ in case these keys do not exist in the source field being parsed.
                          "to", "default@dev.null" ]
       }
     }
+
+[id="plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+  * Value type is <<string,string>>
+  * Supported values are:
+    ** `disabled`: does not use ECS-compatible field names
+    ** `v1`: Elastic Common Schema compliant behavior (warns when `target` isn't set)
+
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
+See <<plugins-{type}s-{plugin}-ecs_metadata>> for detailed information.
 
 [id="plugins-{type}s-{plugin}-exclude_keys"]
 ===== `exclude_keys` 

--- a/lib/logstash/filters/kv.rb
+++ b/lib/logstash/filters/kv.rb
@@ -437,7 +437,9 @@ class LogStash::Filters::KV < LogStash::Filters::Base
     return if kv.empty?
 
     if @target
-      @logger.debug? && @logger.debug("Overwriting existing target field", :target => @target)
+      if event.include?(@target)
+        @logger.debug? && @logger.debug("Overwriting existing target field", field: @target, existing_value: event.get(@target))
+      end
       event.set(@target, kv)
     else
       kv.each{|k, v| event.set(k, v)}

--- a/lib/logstash/filters/kv.rb
+++ b/lib/logstash/filters/kv.rb
@@ -2,6 +2,9 @@
 
 require "logstash/filters/base"
 require "logstash/namespace"
+require 'logstash/plugin_mixins/ecs_compatibility_support'
+require 'logstash/plugin_mixins/ecs_compatibility_support/target_check'
+require 'logstash/plugin_mixins/validator_support/field_reference_validation_adapter'
 require "timeout"
 
 # This filter helps automatically parse messages (or specific event fields)
@@ -29,6 +32,11 @@ require "timeout"
 # `foo=bar&baz=fizz` by setting the `field_split` parameter to `&`.
 class LogStash::Filters::KV < LogStash::Filters::Base
   config_name "kv"
+
+  include LogStash::PluginMixins::ECSCompatibilitySupport
+  include LogStash::PluginMixins::ECSCompatibilitySupport::TargetCheck
+
+  extend LogStash::PluginMixins::ValidatorSupport::FieldReferenceValidationAdapter
 
   # Constants used for transform check
   TRANSFORM_LOWERCASE_KEY = "lowercase"
@@ -201,7 +209,7 @@ class LogStash::Filters::KV < LogStash::Filters::Base
   # For example, to process the `not_the_message` field:
   # [source,ruby]
   #     filter { kv { source => "not_the_message" } }
-  config :source, :validate => :string, :default => "message"
+  config :source, :validate => :field_reference, :default => "message"
 
   # The name of the container to put all of the key-value pairs into.
   #
@@ -211,7 +219,7 @@ class LogStash::Filters::KV < LogStash::Filters::Base
   # For example, to place all keys into the event field kv:
   # [source,ruby]
   #     filter { kv { target => "kv" } }
-  config :target, :validate => :string
+  config :target, :validate => :field_reference
 
   # An array specifying the parsed keys which should be added to the event.
   # By default all keys will be added.

--- a/logstash-filter-kv.gemspec
+++ b/logstash-filter-kv.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
+  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~> 1.3'
+  s.add_runtime_dependency 'logstash-mixin-validator_support', '~> 1.0'
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'insist'

--- a/logstash-filter-kv.gemspec
+++ b/logstash-filter-kv.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-kv'
-  s.version         = '4.4.1'
+  s.version         = '4.5.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parses key-value pairs"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
and validate `source` / `target` as field references

- we rely on the ecs mixin to do the target check (and log an info message)
- there are existing specs checking for target working as expected

closing #90