### PR TITLE
Multiple config tags support when plugin faces runtime error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.7.0
+- Allow attaching multiple tags on failure. The `tag_on_failure` option now also supports an array of strings [#92](https://github.com/logstash-plugins/logstash-filter-kv/issues/92)
+
 ## 4.6.0
  - Added `allow_empty_values` option [#72](https://github.com/logstash-plugins/logstash-filter-kv/pull/72)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -74,7 +74,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-remove_char_value>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-source>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-tag_on_failure>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-tag_on_failure>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-tag_on_timeout>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-timeout_millis>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-transform_key>> |<<string,string>>, one of `["lowercase", "uppercase", "capitalize"]`|No
@@ -372,12 +372,12 @@ For example, to place all keys into the event field kv:
 [id="plugins-{type}s-{plugin}-tag_on_failure"]
 ===== `tag_on_failure`
 
-  * Value type is <<string,string>>
-  * The default value for this setting is `_kv_filter_error`.
+  * Value type is <<array,array>>
+  * The default value for this setting is [`_kv_filter_error`].
 
 When a kv operation causes a runtime exception to be thrown within the plugin,
 the operation is safely aborted without crashing the plugin, and the event is
-tagged with the provided value.
+tagged with the provided values.
 
 [id="plugins-{type}s-{plugin}-tag_on_timeout"]
 ===== `tag_on_timeout`

--- a/lib/logstash/filters/kv.rb
+++ b/lib/logstash/filters/kv.rb
@@ -67,7 +67,7 @@ class LogStash::Filters::KV < LogStash::Filters::Base
   # These characters form a regex character class and thus you must escape special regex
   # characters like `[` or `]` using `\`.
   #
-  # Only leading and trailing characters are trimed from the key.
+  # Only leading and trailing characters are trimmed from the key.
   #
   # For example, to trim `<` `>` `[` `]` and `,` characters from keys:
   # [source,ruby]
@@ -338,7 +338,7 @@ class LogStash::Filters::KV < LogStash::Filters::Base
   config :tag_on_timeout, :validate => :string, :default => '_kv_filter_timeout'
 
   # Tag to apply if kv errors
-  config :tag_on_failure, :validate => :string, :default => '_kv_filter_error'
+  config :tag_on_failure, :validate => :array, :default => ['_kv_filter_error']
 
 
   EMPTY_STRING = ''.freeze
@@ -425,8 +425,8 @@ class LogStash::Filters::KV < LogStash::Filters::Base
 
     @logger.debug? && @logger.debug("KV scan regex", :regex => @scan_re.inspect)
 
-    # divide by float to allow fractionnal seconds, the Timeout class timeout value is in seconds but the underlying
-    # executor resolution is in microseconds so fractionnal second parameter down to microseconds is possible.
+    # divide by float to allow fractional seconds, the Timeout class timeout value is in seconds but the underlying
+    # executor resolution is in microseconds so fractional second parameter down to microseconds is possible.
     # see https://github.com/jruby/jruby/blob/9.2.7.0/core/src/main/java/org/jruby/ext/timeout/Timeout.java#L125
     @timeout_seconds = @timeout_millis / 1000.0
   end
@@ -460,7 +460,7 @@ class LogStash::Filters::KV < LogStash::Filters::Base
     meta = { :exception => ex.message }
     meta[:backtrace] = ex.backtrace if logger.debug?
     logger.warn('Exception while parsing KV', meta)
-    event.tag(@tag_on_failure)
+    @tag_on_failure.each { |tag| event.tag(tag) }
   end
 
   def close
@@ -502,7 +502,7 @@ class LogStash::Filters::KV < LogStash::Filters::Base
 
     value.bytesize < 255 ? "`#{value}`" : "entry too large; first 255 chars are `#{value[0..255].dump}`"
   end
-  
+
   def has_value_splitter?(s)
     s =~ @value_split_re
   end

--- a/logstash-filter-kv.gemspec
+++ b/logstash-filter-kv.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-kv'
-  s.version         = '4.6.0'
+  s.version         = '4.7.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parses key-value pairs"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/kv_spec.rb
+++ b/spec/filters/kv_spec.rb
@@ -460,7 +460,6 @@ describe LogStash::Filters::KV do
     end
   end
 
-
   describe "test data from specific sub source" do
     config <<-CONFIG
       filter {
@@ -518,7 +517,6 @@ describe LogStash::Filters::KV do
       insist { subject.get("[headerskv][X-UUID]") } == "0:15713435944943992"
     end
   end
-
 
   describe "test data from specific sub source and target" do
     config <<-CONFIG
@@ -1059,7 +1057,6 @@ describe "multi character splitting" do
     it_behaves_like "parsing all fields and values"
   end
 
-
   context "example from @guyboertje in #15" do
     let(:message) { 'key1: val1; key2: val2; key3:  https://site/?g={......"...;  CLR  rv:11.0)"..}; key4: val4;' }
     let(:options) {
@@ -1152,6 +1149,17 @@ context 'runtime errors' do
         plugin.filter(event)
         expect(event.get('tags')).to_not be_nil
         expect(event.get('tags')).to include('KV-ERROR')
+        expect(event.get('tags')).to_not include('_kv_filter_error')
+      end
+    end
+    context 'when multiple custom tags are defined' do
+      let(:options) { super().merge("tag_on_failure" => ["kv_FAIL_one", "_kv_fail_TWO"])}
+      it 'tags the event with the custom tag' do
+        plugin.filter(event)
+        expect(event.get('tags')).to_not be_nil
+        expect(event.get('tags')).to include('kv_FAIL_one')
+        expect(event.get('tags')).to include('_kv_fail_TWO')
+        expect(event.get('tags')).to_not include('_kv_filter_error')
       end
     end
   end


### PR DESCRIPTION
## Description
_Note: This PR is a copy of [approved PR](https://github.com/logstash-plugins/logstash-filter-kv/pull/99). Since CLA failed, agreed to raise a copy PR to test the CLA._

Customers are now able set their **custom multiple tags through configuration**. When plugin faces an internal issue, configuration tags can be attached to the _tags_ field.

## Testing
### Unit testing
- Please refer to `when multiple custom tags are defined` context.
### Manual testing
- We can manually raise an exception (`raise "Returning error"`) on [/lib/logstash/filters/kv.rb#L471](https://github.com/mashhurs/logstash-filter-kv/blob/56092c8af1687afd38da189f6877356fa8a8d270/lib/logstash/filters/kv.rb#L471) and check with std input & http output to ES plugins. For this case, the test config and output will be like this:
```
// config
input { stdin { } }
filter { kv {
    source => "message"
    tag_on_failure => ["_kv_filter_error", "_kv_pattern"]
  }
}
output {
    elasticsearch {
        hosts => ["https://localhost:9200"]
        index => "logstash-test-output"
        user => "elastic"
    }
  stdout { codec => rubydebug }
}
```

```
// output
{
        "_index" : "logstash-test-output",
        "_id" : "xptLMn8Bj7JD6-SEtRSm",
        "_score" : 1.0,
        "_source" : {
          "@version" : "1",
          "message" : "key5=error value5=\"Single error\"",
          "host" : {
            "hostname" : "Mashhurs-MacBook-Pro.local"
          },
          "@timestamp" : "2022-02-25T19:11:36.594786Z",
          "event" : {
            "original" : "key5=error value5=\"Single error\""
          },
          "tags" : [
            "_kv_filter_error",
            "_kv_pattern"
          ]
        }
      },
```